### PR TITLE
Robust multiverso integration.

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -26,7 +26,7 @@ cutorch.manualSeedAll(opt.manualSeed)
 
 if opt.multiverso then
    multiverso.init()
-   cutorch.setDevice(multiverso.worker_id() + 1)
+   cutorch.setDevice(multiverso.worker_id() % cutorch.getDeviceCount() + 1)
 end
 
 -- Load previous checkpoint, if it exists

--- a/main.lua
+++ b/main.lua
@@ -15,7 +15,6 @@ local models = require 'models/init'
 local Trainer = require 'train'
 local opts = require 'opts'
 local checkpoints = require 'checkpoints'
-local multiverso = require 'multiverso'
 
 torch.setdefaulttensortype('torch.FloatTensor')
 torch.setnumthreads(1)
@@ -23,6 +22,8 @@ torch.setnumthreads(1)
 local opt = opts.parse(arg)
 torch.manualSeed(opt.manualSeed)
 cutorch.manualSeedAll(opt.manualSeed)
+
+local multiverso = opt.multiverso and require 'multiverso'
 
 if opt.multiverso then
    multiverso.init()


### PR DESCRIPTION
- Do not require multiverso package when not used. (Make sure everything works without installation of multiverso package when the option is not enabled.)
- Fix a bug in `setDevice()` cause the `worker_id` may be larger than largest valid Device ID when running on multiple machines.
